### PR TITLE
automatically ingest audit events. Maintain certs through updates

### DIFF
--- a/deploy/charts/kube-oidc-proxy/Chart.yaml
+++ b/deploy/charts/kube-oidc-proxy/Chart.yaml
@@ -3,7 +3,8 @@ appVersion: "v0.3.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/jetstack/kube-oidc-proxy
 name: kube-oidc-proxy
-version: 0.3.0
+version: 0.3.1
 maintainers:
 - name: mhrabovcin
 - name: joshvanl
+- name: shivanshvij

--- a/deploy/charts/kube-oidc-proxy/templates/secret_tls.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/secret_tls.yaml
@@ -1,26 +1,8 @@
-{{- if and (not .Values.tls.secretName) (.Values.tls.hostname) }}
+{{- if (not .Values.tls.secretName) }}
 {{ $fullname := include "kube-oidc-proxy.fullname" . }}
 {{ $ca := genCA (printf "%s-ca" $fullname) 3650 }}
 {{ $cn := printf "%s.%s.svc.cluster.local" $fullname .Release.Namespace }}
-{{ $server := genSignedCert $cn nil (list .Values.tls.hostname) 365 $ca }}
-
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/tls
-metadata:
-  name: {{ template "kube-oidc-proxy.fullname" . }}-tls
-  labels:
-{{ include "kube-oidc-proxy.labels" . | indent 4 }}
-data:
-  tls.crt: {{ b64enc $server.Cert }}
-  tls.key: {{ b64enc $server.Key }}
-  ca.crt: {{ b64enc $ca.Cert }}
-{{- else }}
-
-{{ $fullname := include "kube-oidc-proxy.fullname" . }}
-{{ $ca := genCA (printf "%s-ca" $fullname) 3650 }}
-{{ $cn := printf "%s.%s.svc.cluster.local" $fullname .Release.Namespace }}
-{{ $server := genSignedCert $cn nil nil 365 $ca }}
+{{ $server := genSignedCert $cn nil (ternary nil (list .Values.tls.hostName) (empty .Values.tls.hostName)) 365 $ca }}
 
 apiVersion: v1
 kind: Secret

--- a/deploy/charts/kube-oidc-proxy/templates/secret_tls.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/secret_tls.yaml
@@ -1,4 +1,22 @@
-{{- if (not .Values.tls.secretName) }}
+{{- if and (not .Values.tls.secretName) (.Values.tls.hostname) }}
+{{ $fullname := include "kube-oidc-proxy.fullname" . }}
+{{ $ca := genCA (printf "%s-ca" $fullname) 3650 }}
+{{ $cn := printf "%s.%s.svc.cluster.local" $fullname .Release.Namespace }}
+{{ $server := genSignedCert $cn nil (list .Values.tls.hostname) 365 $ca }}
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ template "kube-oidc-proxy.fullname" . }}-tls
+  labels:
+{{ include "kube-oidc-proxy.labels" . | indent 4 }}
+data:
+  tls.crt: {{ b64enc $server.Cert }}
+  tls.key: {{ b64enc $server.Key }}
+  ca.crt: {{ b64enc $ca.Cert }}
+{{- else }}
+
 {{ $fullname := include "kube-oidc-proxy.fullname" . }}
 {{ $ca := genCA (printf "%s-ca" $fullname) 3650 }}
 {{ $cn := printf "%s.%s.svc.cluster.local" $fullname .Release.Namespace }}
@@ -14,4 +32,5 @@ metadata:
 data:
   tls.crt: {{ b64enc $server.Cert }}
   tls.key: {{ b64enc $server.Key }}
-{{ end }}
+  ca.crt: {{ b64enc $ca.Cert }}
+{{- end }}

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -40,14 +40,14 @@ oidc:
   # values.
   clientId: ""
   issuerUrl: ""
-  usernameClaim: "email"
+  usernameClaim: email
 
   # PEM encoded value of CA cert that will verify TLS connection to
   # OIDC issuer URL. If not provided, default hosts root CA's will be used.
   caPEM:
 
   usernamePrefix: "banyan:"
-  groupsClaim: "roles"
+  groupsClaim: roles
   groupsPrefix: "banyan:"
 
   signingAlgs:

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -19,7 +19,9 @@ service:
   annotations:
     # You can use this field to add annotations to the Service.
     # Define it in a key-value pairs. E.g.
-    # service.beta.kubernetes.io/aws-load-balancer-internal: true
+    # service.beta.kubernetes.io/aws-load-balancer-internal: "true" ## AWS
+    # service.beta.kubernetes.io/azure-load-balancer-internal: "true" ## Azure
+    # cloud.google.com/load-balancer-type: "Internal" ## GCP
 
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
@@ -28,6 +30,8 @@ tls:
   # `secretName` must be a name of Secret of TLS type. If not provided a
   # self-signed certificate will get generated.
   secretName:
+  # `hostName` is the domain name that will be optionally added to the self-signed certificate.
+  hostName:
 
 # These values needs to be set in overrides in order to get kube-oidc-proxy
 # working.

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -14,7 +14,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 service:
-  type: ClusterIP
+  type: LoadBalancer
   port: 443
   annotations:
     # You can use this field to add annotations to the Service.
@@ -40,15 +40,15 @@ oidc:
   # values.
   clientId: ""
   issuerUrl: ""
-  usernameClaim: ""
+  usernameClaim: "email"
 
   # PEM encoded value of CA cert that will verify TLS connection to
   # OIDC issuer URL. If not provided, default hosts root CA's will be used.
   caPEM:
 
-  usernamePrefix:
-  groupsClaim:
-  groupsPrefix:
+  usernamePrefix: "banyan:"
+  groupsClaim: "roles"
+  groupsPrefix: "banyan:"
 
   signingAlgs:
     - RS256


### PR DESCRIPTION
Automatically push audit events to banyan.
No longer need to update service spec if doing a helm upgrade.