### PR TITLE
push audit events to banyan events

### DIFF
--- a/deploy/charts/kube-oidc-proxy-cert/.helmignore
+++ b/deploy/charts/kube-oidc-proxy-cert/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/kube-oidc-proxy-cert/Chart.yaml
+++ b/deploy/charts/kube-oidc-proxy-cert/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: kube-oidc-proxy-cert
+description: Generates a cert secret to be used by kube-oidc-proxy
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/deploy/charts/kube-oidc-proxy-cert/templates/_helpers.tpl
+++ b/deploy/charts/kube-oidc-proxy-cert/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kube-oidc-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kube-oidc-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-oidc-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kube-oidc-proxy.labels" -}}
+app.kubernetes.io/name: {{ include "kube-oidc-proxy.name" . }}
+helm.sh/chart: {{ include "kube-oidc-proxy.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Required claims serialized to CLI argument
+*/}}
+{{- define "requiredClaims" -}}
+{{- if .Values.oidc.requiredClaims -}}
+{{- $local := (list) -}}
+{{- range $k, $v := .Values.oidc.requiredClaims -}}
+{{- $local = (printf "%s=%s" $k $v | append $local) -}}
+{{- end -}}
+{{ join "," $local }}
+{{- end -}}
+{{- end -}}
+

--- a/deploy/charts/kube-oidc-proxy-cert/templates/secret_tls.yaml
+++ b/deploy/charts/kube-oidc-proxy-cert/templates/secret_tls.yaml
@@ -1,0 +1,16 @@
+{{ $fullname := include "kube-oidc-proxy.fullname" . }}
+{{ $ca := genCA (printf "%s-ca" $fullname) 3650 }}
+{{ $cn := printf "%s.%s.svc.cluster.local" $fullname .Release.Namespace }}
+{{ $server := genSignedCert $cn nil (ternary nil (list .Values.tls.hostName) (empty .Values.tls.hostName)) 1825 $ca }}
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ template "kube-oidc-proxy.fullname" . }}-tls
+  labels:
+{{ include "kube-oidc-proxy.labels" . | indent 4 }}
+data:
+  tls.crt: {{ b64enc $server.Cert }}
+  tls.key: {{ b64enc $server.Key }}
+  ca.crt: {{ b64enc $ca.Cert }}

--- a/deploy/charts/kube-oidc-proxy-cert/values.yaml
+++ b/deploy/charts/kube-oidc-proxy-cert/values.yaml
@@ -1,0 +1,2 @@
+tls:
+  hostName:

--- a/deploy/charts/kube-oidc-proxy/Chart.yaml
+++ b/deploy/charts/kube-oidc-proxy/Chart.yaml
@@ -3,8 +3,9 @@ appVersion: "v0.3.0"
 description: A Helm chart for kube-oidc-proxy
 home: https://github.com/jetstack/kube-oidc-proxy
 name: kube-oidc-proxy
-version: 0.3.1
+version: 0.3.2
 maintainers:
 - name: mhrabovcin
 - name: joshvanl
 - name: shivanshvij
+- name: tsfenwick

--- a/deploy/charts/kube-oidc-proxy/configmap.yaml
+++ b/deploy/charts/kube-oidc-proxy/configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-oidc-proxy-audit-policy
+  namespace: kube-oidc-proxy-ns
+data:
+  audit.yaml: |
+    apiVersion: audit.k8s.io/v1
+    kind: Policy
+    rules:
+    - level: Metadata
+  webhook.yaml: |
+    # apiVersion: v1
+    kind: Config
+    clusters:
+    - cluster:
+        server: http://127.0.0.1:8082/events/kubernetes
+      name: logstash
+    contexts:
+    - context:
+        cluster: logstash
+        user: ""
+      name: default-context
+    current-context: default-context
+    preferences: {}
+    users: []

--- a/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/deployment.yaml
@@ -137,6 +137,35 @@ spec:
             mountPath: /etc/oidc/tls
             readOnly: true
           {{- if .Values.extraVolumeMounts }}{{ toYaml .Values.extraVolumeMounts | trim | nindent 10 }}{{ end }}
+      - name: {{ .Values.auditProxyImage.name }}
+        image: "{{ .Values.auditProxyImage.repository }}:{{ .Values.auditProxyImage.tag }}"
+        imagePullPolicy: {{ .Values.auditProxyImage.pullPolicy }}
+        ports:
+        - containerPort: 8082 # only listens to calls from localhost
+        - containerPort: 8083 # externally available
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8083
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        command: ["/app"]
+        env:
+        - name: BNN_K8S_AUDIT_PROXY_SERVICE_NAME
+          value: {{ .Values.auditProxy.serviceName }}
+        {{- if .Values.auditProxy.restapiUrl }}
+        - name: BNN_K8S_AUDIT_PROXY_RESTAPI_URL
+          value: {{ .Values.auditProxy.restapiUrl }}
+        {{ end }}
+        {{- if .Values.auditProxy.refreshToken }}
+        - name: BNN_K8S_AUDIT_PROXY_REFRESH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "kube-oidc-proxy.fullname" . }}-config
+              key: audit-proxy.refresh-token
+        {{ end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         {{ if .Values.oidc.caPEM }}
         - name: kube-oidc-proxy-config

--- a/deploy/charts/kube-oidc-proxy/templates/secret_config.yaml
+++ b/deploy/charts/kube-oidc-proxy/templates/secret_config.yaml
@@ -1,25 +1,48 @@
 apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kube-oidc-proxy.fullname" . }}-config
+  labels:
+{{ include "kube-oidc-proxy.labels" . | indent 4 }}
+type: Opaque
 data:
-  {{ if .Values.oidc.caPEM }}
+  {{- if .Values.oidc.caPEM }}
   oidc.ca-pem: {{ .Values.oidc.caPEM | default "" | b64enc }}
-  {{ end }}
+  {{- end }}
+
+  {{- if .Values.oidc.issuerUrl }}
   oidc.issuer-url: {{ .Values.oidc.issuerUrl | b64enc }}
-  oidc.username-claim: {{ .Values.oidc.usernameClaim | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.usernameClaim }}
+  oidc.username-claim: {{ .Values.oidc.usernameClaim | default "" | b64enc }}
+  {{- end }}
+
+  {{- if .Values.oidc.clientId }}
   oidc.client-id: {{ .Values.oidc.clientId | b64enc }}
+  {{- end }}
+
   {{- if .Values.oidc.usernamePrefix }}
-  oidc.username-prefix: {{ .Values.oidc.usernamePrefix | b64enc }}
+  oidc.username-prefix: {{ .Values.oidc.usernamePrefix | default "" | b64enc }}
   {{- end }}
+
   {{- if .Values.oidc.groupsClaim }}
-  oidc.groups-claim: {{ .Values.oidc.groupsClaim | b64enc }}
+  oidc.groups-claim: {{ .Values.oidc.groupsClaim | default "" | b64enc }}
   {{- end }}
+
   {{- if .Values.oidc.groupsPrefix }}
-  oidc.groups-prefix: {{ .Values.oidc.groupsPrefix | b64enc }}
+  oidc.groups-prefix: {{ .Values.oidc.groupsPrefix | default "" | b64enc }}
   {{- end }}
+
   {{- if .Values.oidc.signingAlgs }}
-  oidc.signing-algs: {{ join "," .Values.oidc.signingAlgs | b64enc }}
+  oidc.signing-algs: {{ join "," .Values.oidc.signingAlgs | default "" | b64enc }}
   {{- end }}
-  {{ if .Values.oidc.requiredClaims }}
+
+  {{- if .Values.oidc.requiredClaims }}
   oidc.required-claims: {{ include "requiredClaims" . | b64enc }}
+  {{- end }}
+  {{ if .Values.auditProxy.refreshToken }}
+  audit-proxy.refresh-token: {{ .Values.auditProxy.refreshToken | b64enc }}
   {{- end }}
 kind: Secret
 metadata:

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -9,6 +9,19 @@ image:
   tag: v0.3.0
   pullPolicy: IfNotPresent
 
+auditProxyImage:
+  name: bnn-audit-proxy
+  repository: gcr.io/banyan-pub/k8s-audit-proxy
+  tag: v0.0.5
+  pullPolicy: IfNotPresent
+
+auditProxy:
+  # required
+  serviceName:
+  # required
+  refreshToken:
+  restapiUrl: "https://net.banyanops.com"
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -29,9 +42,7 @@ service:
 tls:
   # `secretName` must be a name of Secret of TLS type. If not provided a
   # self-signed certificate will get generated.
-  secretName:
-  # `hostName` is the domain name that will be optionally added to the self-signed certificate.
-  hostName:
+  secretName: selfsigned-kube-oidc-proxy-cert-tls
 
 # These values needs to be set in overrides in order to get kube-oidc-proxy
 # working.
@@ -66,20 +77,27 @@ extraImpersonationHeaders:
   clientIP: false
   #headers: key1=foo,key2=bar,key1=bar
 
-extraArgs: {}
-  #audit-log-path: /audit-log
-  #audit-policy-file: /audit/audit.yaml
+extraArgs:
+  audit-webhook-config-file: /audit/webhook.yaml
+  audit-policy-file: /audit/audit.yaml
+  audit-webhook-batch-max-wait: 300s #5 mins
+  audit-webhook-initial-backoff: 30s
+  audit-webhook-batch-max-size: 400
+  audit-webhook-batch-throttle-burst: 4
+  audit-webhook-batch-throttle-qps: .067 # every 15seconds
+  audit-webhook-batch-buffer-size: 10000
+  audit-webhook-truncate-enabled: true
 
-extraVolumeMounts: {}
-  #- name: audit
-  #  mountPath: /audit
-  #  readOnly: true
+extraVolumeMounts:
+  - name: audit
+    mountPath: /audit
+    readOnly: true
 
-extraVolumes: {}
-  #- configMap:
-      #defaultMode: 420
-      #name: kube-oidc-proxy-policy
-    #name: audit
+extraVolumes:
+  - configMap:
+      defaultMode: 420
+      name: kube-oidc-proxy-audit-policy
+    name: audit
 
 ingress:
   enabled: false


### PR DESCRIPTION
automatically push audit events to banyan events.
no longer generate a new cert for every helm upgrade.